### PR TITLE
update logo on the signup / login screens #48

### DIFF
--- a/lib/vachan_web/auth_overrides.ex
+++ b/lib/vachan_web/auth_overrides.ex
@@ -1,0 +1,10 @@
+defmodule VachanWeb.AuthOverrides do
+  use AshAuthentication.Phoenix.Overrides
+  alias AshAuthentication.Phoenix.Components
+
+  override Components.Banner do
+    set :image_url, "/images/vaak-logo.svg"
+    set :image_class, "object-scale-down object-top h-48 w-96" # Adjust size and position here
+    #absolute top-20px left-auto
+  end
+end                  

--- a/lib/vachan_web/router.ex
+++ b/lib/vachan_web/router.ex
@@ -1,3 +1,5 @@
+import VachanWeb.AuthOverrides          
+
 defmodule VachanWeb.Router do
   use VachanWeb, :router
   use AshAuthentication.Phoenix.Router
@@ -26,7 +28,9 @@ defmodule VachanWeb.Router do
     live "/verify-email", VerifyEmailLive
     # Leave out `register_path` and `reset_path` if you don't want to support
     # user registration and/or password resets respectively.
-    sign_in_route(register_path: "/register", reset_path: "/reset")
+    #sign_in_route(register_path: "/register", reset_path: "/reset")
+    # Define your authentication routes with overrides
+    sign_in_route(register_path: "/register", reset_path: "/reset", overrides: [VachanWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default])
 
     sign_out_route AuthController
     auth_routes_for Vachan.Accounts.User, to: AuthController


### PR DESCRIPTION
The sign-up / login screens were using the default logo of Ash Framework, updated it to the vaak logo.