### PR TITLE
Fix bug: floating ee on top left edit lists page

### DIFF
--- a/lib/vachan_web/live/list_live/show.html.heex
+++ b/lib/vachan_web/live/list_live/show.html.heex
@@ -1,4 +1,4 @@
-ee<.header>
+<.header>
   List <%= @list.id %>
   <:subtitle>This is a list record from your database.</:subtitle>
   <:actions>


### PR DESCRIPTION
Fix "ee" floating up at top left corner

Issue #89 reported a problem where the text "ee" was floating up at the top left corner of the page.

This commit resolves the issue reported in #89 by implementing the necessary fixes.