### PR TITLE
 Fix form bug by making attributes public

### DIFF
--- a/lib/vachan/sender_profiles/resources/sender_profile.ex
+++ b/lib/vachan/sender_profiles/resources/sender_profile.ex
@@ -26,7 +26,7 @@ defmodule Vachan.SenderProfiles.SenderProfile do
 
   actions do
     defaults [:read, :create, :update, :destroy]
-
+    default_accept :*
     read :by_id do
       argument :id, :uuid, allow_nil?: false
       get? true
@@ -52,16 +52,16 @@ defmodule Vachan.SenderProfiles.SenderProfile do
       default :smtp
     end
 
-    attribute :username, :string, allow_nil?: true
-    attribute :password, :string, allow_nil?: true
-    attribute :api_key, :string, allow_nil?: true
-    attribute :smtp_host, :string, allow_nil?: true
-    attribute :smtp_port, :string, allow_nil?: true
+    attribute :username, :string, allow_nil?: true, public?: true
+    attribute :password, :string, allow_nil?: true, public?: true
+    attribute :api_key, :string, allow_nil?: true, public?: true
+    attribute :smtp_host, :string, allow_nil?: true, public?: true
+    attribute :smtp_port, :string, allow_nil?: true, public?: true
 
-    attribute :name, :string, allow_nil?: false
-    attribute :email, :ci_string, allow_nil?: false
+    attribute :name, :string, allow_nil?: false, public?: true
+    attribute :email, :ci_string, allow_nil?: false, public?: true
 
-    attribute :title, :string, allow_nil?: false
+    attribute :title, :string, allow_nil?: false, public?: true
   end
 
   identities do


### PR DESCRIPTION
Add public? : true statement to fix a bug where the form was not accepting details. This change is necessary to comply with Ash 3.0 requirements, which require attributes to be public for proper form submission.