### PR TITLE
feat: add placeholders to form input fields (#89) 

### DIFF
--- a/lib/vachan_web/live/list_live/form_component.ex
+++ b/lib/vachan_web/live/list_live/form_component.ex
@@ -19,7 +19,7 @@ defmodule VachanWeb.ListLive.FormComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <.input field={@form[:name]} type="text" label="Name" placeholder="Enter list name" />
+        <.input field={@form[:name]} type="text" label="Name" placeholder="List name" />
 
         <:actions>
           <.button phx-disable-with="Saving...">Save list</.button>

--- a/lib/vachan_web/live/list_live/form_component.ex
+++ b/lib/vachan_web/live/list_live/form_component.ex
@@ -19,7 +19,7 @@ defmodule VachanWeb.ListLive.FormComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <.input field={@form[:name]} type="text" label="Name" />
+        <.input field={@form[:name]} type="text" label="Name" placeholder="Enter list name" />
 
         <:actions>
           <.button phx-disable-with="Saving...">Save list</.button>

--- a/lib/vachan_web/live/person_live/form_component.ex
+++ b/lib/vachan_web/live/person_live/form_component.ex
@@ -19,9 +19,9 @@ defmodule VachanWeb.PersonLive.FormComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <.input field={@form[:first_name]} type="text" label="First name" />
-        <.input field={@form[:last_name]} type="text" label="Last name" />
-        <.input field={@form[:email]} type="email" label="Email" />
+        <.input field={@form[:first_name]} type="text" label="First name" placeholder="John"/>
+        <.input field={@form[:last_name]} type="text" label="Last name" placeholder="Doe"/>
+        <.input field={@form[:email]} type="email" label="Email" placeholder="john.doe@example.com"/>
 
         <:actions>
           <.button phx-disable-with="Saving...">Save Person</.button>

--- a/lib/vachan_web/live/person_live/form_component.ex
+++ b/lib/vachan_web/live/person_live/form_component.ex
@@ -19,9 +19,9 @@ defmodule VachanWeb.PersonLive.FormComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <.input field={@form[:first_name]} type="text" label="First name" placeholder="John"/>
-        <.input field={@form[:last_name]} type="text" label="Last name" placeholder="Doe"/>
-        <.input field={@form[:email]} type="email" label="Email" placeholder="john.doe@example.com"/>
+        <.input field={@form[:first_name]} type="text" label="First name" placeholder="First Name"/>
+        <.input field={@form[:last_name]} type="text" label="Last name" placeholder="Last Name"/>
+        <.input field={@form[:email]} type="email" label="Email" placeholder="E-mail"/>
 
         <:actions>
           <.button phx-disable-with="Saving...">Save Person</.button>

--- a/lib/vachan_web/live/sender_profile_live/form_component.ex
+++ b/lib/vachan_web/live/sender_profile_live/form_component.ex
@@ -19,14 +19,14 @@ defmodule VachanWeb.SenderProfileLive.FormComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <.input field={@form[:title]} type="text" label="Sender Profile's title" />
-        <.input field={@form[:name]} type="text" label="Sender's Name" />
-        <.input field={@form[:email]} type="email" label="Sender's Email" />
+        <.input field={@form[:title]} type="text" label="Sender Profile's title" placeholder="Marketing Campaign"/>
+        <.input field={@form[:name]} type="text" label="Sender's Name" placeholder="John Doe"/>
+        <.input field={@form[:email]} type="email" label="Sender's Email" placeholder="john.doe@example.com" />
 
-        <.input field={@form[:smtp_host]} type="text" label="SMTP Server's Address" />
-        <.input field={@form[:smtp_port]} type="number" label="SMTP Server's Port" />
-        <.input field={@form[:username]} type="text" label="SMTP username" />
-        <.input field={@form[:password]} type="text" label="SMTP password" />
+        <.input field={@form[:smtp_host]} type="text" label="SMTP Server's Address" placeholder="smtp.example.com" />
+        <.input field={@form[:smtp_port]} type="number" label="SMTP Server's Port" placeholder="587" />
+        <.input field={@form[:username]} type="text" label="SMTP username"  placeholder="smtp_user"/>
+        <.input field={@form[:password]} type="text" label="SMTP password" placeholder="*********"/>
 
         <:actions>
           <.button phx-disable-with="Saving...">Save Sender Profile</.button>

--- a/lib/vachan_web/live/sender_profile_live/form_component.ex
+++ b/lib/vachan_web/live/sender_profile_live/form_component.ex
@@ -19,14 +19,14 @@ defmodule VachanWeb.SenderProfileLive.FormComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <.input field={@form[:title]} type="text" label="Sender Profile's title" placeholder="Marketing Campaign"/>
-        <.input field={@form[:name]} type="text" label="Sender's Name" placeholder="John Doe"/>
-        <.input field={@form[:email]} type="email" label="Sender's Email" placeholder="john.doe@example.com" />
+        <.input field={@form[:title]} type="text" label="Sender Profile's title" placeholder="Profile title"/>
+        <.input field={@form[:name]} type="text" label="Sender's Name" placeholder="Name"/>
+        <.input field={@form[:email]} type="email" label="Sender's Email" placeholder="E-mail" />
 
-        <.input field={@form[:smtp_host]} type="text" label="SMTP Server's Address" placeholder="smtp.example.com" />
-        <.input field={@form[:smtp_port]} type="number" label="SMTP Server's Port" placeholder="587" />
-        <.input field={@form[:username]} type="text" label="SMTP username"  placeholder="smtp_user"/>
-        <.input field={@form[:password]} type="text" label="SMTP password" placeholder="*********"/>
+        <.input field={@form[:smtp_host]} type="text" label="SMTP Server's Address" placeholder="Server's address" />
+        <.input field={@form[:smtp_port]} type="number" label="SMTP Server's Port" placeholder="Server's port" />
+        <.input field={@form[:username]} type="text" label="SMTP username"  placeholder="Username"/>
+        <.input field={@form[:password]} type="text" label="SMTP password" placeholder="Password...."/>
 
         <:actions>
           <.button phx-disable-with="Saving...">Save Sender Profile</.button>


### PR DESCRIPTION
feat: add placeholders to form input fields (#89)

Fix issue mentioned in #89 we need placeholders for input boxes everywhere. 

This commit addresses the issue mentioned in #89 by implementing the necessary changes to resolve it.