### PR TITLE
feature: add placeholders to input fields (#89)

### DIFF
--- a/lib/vachan_web/live/list_live/form_component.ex
+++ b/lib/vachan_web/live/list_live/form_component.ex
@@ -19,7 +19,7 @@ defmodule VachanWeb.ListLive.FormComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <.input field={@form[:name]} type="text" label="Name" />
+        <.input field={@form[:name]} type="text" label="Name" placeholder="List Name"/>
 
         <:actions>
           <.button phx-disable-with="Saving...">Save list</.button>

--- a/lib/vachan_web/live/person_live/form_component.ex
+++ b/lib/vachan_web/live/person_live/form_component.ex
@@ -19,9 +19,9 @@ defmodule VachanWeb.PersonLive.FormComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <.input field={@form[:first_name]} type="text" label="First name" pattern="[A-Za-z]+" minlength="2" />
-        <.input field={@form[:last_name]} type="text" label="Last name" pattern="[A-Za-z]+" minlength="2"/>
-        <.input field={@form[:email]} type="email" label="Email" />
+        <.input field={@form[:first_name]} type="text" label="First name" placeholder="First Name" pattern="[A-Za-z]+" minlength="2" />
+        <.input field={@form[:last_name]} type="text" label="Last name" placeholder="Last Name" pattern="[A-Za-z]+" minlength="2"/>
+        <.input field={@form[:email]} type="email" placeholder="E-mail" label="Email" />
 
         <:actions>
           <.button phx-disable-with="Saving...">Save Person</.button>

--- a/lib/vachan_web/live/sender_profile_live/form_component.ex
+++ b/lib/vachan_web/live/sender_profile_live/form_component.ex
@@ -19,14 +19,14 @@ defmodule VachanWeb.SenderProfileLive.FormComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <.input field={@form[:title]} type="text" label="Sender Profile's title" />
-        <.input field={@form[:name]} type="text" label="Sender's Name" />
-        <.input field={@form[:email]} type="email" label="Sender's Email" />
+        <.input field={@form[:title]} type="text" label="Sender Profile's title" placeholder="Profile's title"/>
+        <.input field={@form[:name]} type="text" label="Sender's Name" placeholder="Name"/>
+        <.input field={@form[:email]} type="email" label="Sender's Email" placeholder="E-mail" />
 
-        <.input field={@form[:smtp_host]} type="text" label="SMTP Server's Address" />
-        <.input field={@form[:smtp_port]} type="number" label="SMTP Server's Port" />
-        <.input field={@form[:username]} type="text" label="SMTP username" />
-        <.input field={@form[:password]} type="text" label="SMTP password" />
+        <.input field={@form[:smtp_host]} type="text" label="SMTP Server's Address" placeholder="Server's address"/>
+        <.input field={@form[:smtp_port]} type="number" label="SMTP Server's Port" placeholder="Server's port"/>
+        <.input field={@form[:username]} type="text" label="SMTP username" placeholder="Username"/>
+        <.input field={@form[:password]} type="text" label="SMTP password" placeholder="Password...."/>
 
         <:actions>
           <.button phx-disable-with="Saving...">Save Sender Profile</.button>


### PR DESCRIPTION
feat: add placeholders to input fields across different forms. 

Fix issue mentioned in #89 we need placeholders for input boxes everywhere.