### PR TITLE
Feature/smtp encrypt

### DIFF
--- a/lib/vachan_web/live/sender_profile_live/form_component.ex
+++ b/lib/vachan_web/live/sender_profile_live/form_component.ex
@@ -72,8 +72,23 @@ defmodule VachanWeb.SenderProfileLive.FormComponent do
 
   @impl true
   def handle_event("save", %{"form" => sender_profile_params}, socket) do
-    save_sender_profile(socket, socket.assigns.action, sender_profile_params)
+    updated_params = hash_password_if_present(sender_profile_params)
+    save_sender_profile(socket, socket.assigns.action, updated_params)
   end
+
+  defp hash_password_if_present(params) do
+    case Map.get(params, "password", "") do
+      "" -> params
+      plain_password ->
+        hashed_password = hash_password(plain_password)
+        Map.put(params, "password", hashed_password)
+    end
+  end
+
+  defp hash_password(password) do
+    Bcrypt.hash_pwd_salt(password)
+  end
+
 
   defp save_sender_profile(socket, :edit, sender_profile_params) do
     form = AshPhoenix.Form.validate(socket.assigns.form, sender_profile_params)

--- a/lib/vachan_web/live/sender_profile_live/index.ex
+++ b/lib/vachan_web/live/sender_profile_live/index.ex
@@ -14,21 +14,10 @@ defmodule VachanWeb.SenderProfileLive.Index do
     IO.inspect(params, label: "Handle Params")
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
-
+  >
   defp apply_action(socket, :edit, %{"id" => id} = params) do
     sender_profile = SenderProfile.get_by_id!(id, ash_opts(socket))
-    smtp_password = Map.get(params, "password")
-
-    updated_sender_profile =
-      if smtp_password != "" do
-        hashed_password = hash_password(smtp_password)
-        IO.inspect(hashed_password, label: "Hashed Password - Edit")
-        %SenderProfile{sender_profile | password: hashed_password}
-      else
-        sender_profile
-      end
-
-    IO.inspect(updated_sender_profile, label: "Updated Sender Profile - Edit")
+    updated_sender_profile = sender_profile
 
     socket
     |> assign(:page_title, "Edit Sender Profile")
@@ -45,17 +34,7 @@ defmodule VachanWeb.SenderProfileLive.Index do
   end
 
   defp apply_action(socket, :new, params) do
-    smtp_password = Map.get(params, "password")
-
-    hashed_password = hash_password(smtp_password)
-    IO.inspect(hashed_password, label: "Hashed Password - New")
-
-    sender_profile = %SenderProfile{
-      password: hashed_password
-    }
-
-    IO.inspect(sender_profile, label: "New Sender Profile")
-
+    sender_profile = %SenderProfile{}
     socket
     |> assign(:page_title, "New Sender Profile")
     |> assign(:sender_profile, sender_profile)
@@ -80,14 +59,5 @@ defmodule VachanWeb.SenderProfileLive.Index do
     Enum.filter(sender_profiles, fn sender_profile ->
       String.contains?(String.capitalize(sender_profile.title), capitalized_query)
     end)
-  end
-
-  defp hash_password(password) do
-    IO.inspect(password, label: "Hashing Password")
-    Bcrypt.hash_pwd_salt(password)
-  end
-
-  def verify_password(plain_password, hashed_password) do
-    Bcrypt.verify_pass(plain_password, hashed_password)
   end
 end

--- a/lib/vachan_web/live/sender_profile_live/index.ex
+++ b/lib/vachan_web/live/sender_profile_live/index.ex
@@ -2,42 +2,68 @@ defmodule VachanWeb.SenderProfileLive.Index do
   use VachanWeb, :live_view
 
   alias Vachan.SenderProfiles.SenderProfile
+  require Logger
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok,
-     socket
-     |> stream(:sender_profiles, [])}
+    {:ok, socket |> stream(:sender_profiles, [])}
   end
 
   @impl true
   def handle_params(params, _url, socket) do
+    IO.inspect(params, label: "Handle Params")
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
-  defp apply_action(socket, :edit, %{"id" => id}) do
+  defp apply_action(socket, :edit, %{"id" => id} = params) do
+    sender_profile = SenderProfile.get_by_id!(id, ash_opts(socket))
+    smtp_password = Map.get(params, "password")
+
+    updated_sender_profile =
+      if smtp_password != "" do
+        hashed_password = hash_password(smtp_password)
+        IO.inspect(hashed_password, label: "Hashed Password - Edit")
+        %SenderProfile{sender_profile | password: hashed_password}
+      else
+        sender_profile
+      end
+
+    IO.inspect(updated_sender_profile, label: "Updated Sender Profile - Edit")
+
     socket
     |> assign(:page_title, "Edit Sender Profile")
-    |> assign(:sender_profile, SenderProfile.get_by_id!(id, ash_opts(socket)))
+    |> assign(:sender_profile, updated_sender_profile)
   end
 
   defp apply_action(socket, :index, _params) do
     sender_profiles = SenderProfile.read_all!(ash_opts(socket))
-
+    IO.inspect(sender_profiles, label: "Sender Profiles - Index")
     socket
     |> stream(:sender_profiles, sender_profiles)
     |> assign(:sender_profile, nil)
     |> assign(:page_title, "Sender Profiles")
   end
 
-  defp apply_action(socket, :new, _params) do
+  defp apply_action(socket, :new, params) do
+    smtp_password = Map.get(params, "password")
+
+    hashed_password = hash_password(smtp_password)
+    IO.inspect(hashed_password, label: "Hashed Password - New")
+
+    sender_profile = %SenderProfile{
+      password: hashed_password
+    }
+
+    IO.inspect(sender_profile, label: "New Sender Profile")
+
     socket
     |> assign(:page_title, "New Sender Profile")
-    |> assign(:sender_profile, %SenderProfile{})
+    |> assign(:sender_profile, sender_profile)
   end
 
   @impl true
   def handle_event("search", %{"query" => query}, socket) do
+    IO.inspect(query, label: "Search Query")
     sender_profiles = search_people_by_sender_profile_name(query, socket)
 
     if String.trim(query) == "" do
@@ -54,5 +80,14 @@ defmodule VachanWeb.SenderProfileLive.Index do
     Enum.filter(sender_profiles, fn sender_profile ->
       String.contains?(String.capitalize(sender_profile.title), capitalized_query)
     end)
+  end
+
+  defp hash_password(password) do
+    IO.inspect(password, label: "Hashing Password")
+    Bcrypt.hash_pwd_salt(password)
+  end
+
+  def verify_password(plain_password, hashed_password) do
+    Bcrypt.verify_pass(plain_password, hashed_password)
   end
 end

--- a/lib/vachan_web/live/sender_profile_live/index.html.heex
+++ b/lib/vachan_web/live/sender_profile_live/index.html.heex
@@ -18,7 +18,6 @@
   <:col :let={{_id, sender_profile}} label="Sender's Email"><%= sender_profile.email %></:col>
 
   <:col :let={{_id, sender_profile}} label="SMTP Username"><%= sender_profile.username %></:col>
-  <:col :let={{_id, sender_profile}} label="SMTP Password"><%= sender_profile.password %></:col>
   <:col :let={{_id, sender_profile}} label="SMTP Hostname"><%= sender_profile.smtp_host %></:col>
   <:col :let={{_id, sender_profile}} label="SMTP Port"><%= sender_profile.smtp_port %></:col>
   <:action :let={{_id, sender_profile}}>

--- a/lib/vachan_web/live/sender_profile_live/show.html.heex
+++ b/lib/vachan_web/live/sender_profile_live/show.html.heex
@@ -14,7 +14,6 @@
   <:item title="Sender's Email"><%= @sender_profile.email %></:item>
 
   <:item title="SMTP Username"><%= @sender_profile.username %></:item>
-  <:item title="SMTP Password"><%= @sender_profile.password %></:item>
   <:item title="SMTP Hostname"><%= @sender_profile.smtp_host %></:item>
   <:item title="SMTP Port"><%= @sender_profile.smtp_port %></:item>
 </.list>

--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,8 @@ defmodule Vachan.MixProject do
       {:tls_certificate_check, "~> 1.22"},
       {:certifi, "~> 2.13"},
       {:ash_state_machine, "~> 0.2.3"},
-      {:picosat_elixir, "~> 0.2"}
+      {:picosat_elixir, "~> 0.2"},
+      {:bcrypt_elixir, "~> 3.0"}
     ]
   end
 


### PR DESCRIPTION
Fix: Issue mentioned in #89 smtp-password need encryption

feat: Hash SMTP password and remove it from sender_profile list page

- Implemented password hashing for SMTP password using Bcrypt in sender profile form submissions
- Added `hash_password_if_present/1` function to handle conditional password hashing
- Updated `handle_event/3` for "validate" and "save" events to incorporate password hashing
- Removed SMTP password from the sender_profile list page for security reasons
- Ensured the application no longer displays plaintext SMTP passwords in any views


