### PR TITLE
Fix tooltip targeting for settings and logout buttons

### DIFF
--- a/lib/vachan_web/live/common/sidebar_menu.ex
+++ b/lib/vachan_web/live/common/sidebar_menu.ex
@@ -139,11 +139,19 @@ defmodule VachanWeb.SidebarMenuLiveComponent do
         </div>
         <a
           href="/sign-out"
-          data-tooltip-target="tooltip-settings"
+          data-tooltip-target="tooltip-logout"
           class="inline-flex justify-center p-2 text-gray-500 rounded cursor-pointer dark:text-gray-400 dark:hover:text-white hover:text-gray-900 hover:bg-customBackground_header dark:hover:bg-gray-600"
         >
           Logout
         </a>
+        <div
+          id="tooltip-logout"
+          role="tooltip"
+          class="inline-block absolute invisible z-10 py-2 px-3 text-sm font-medium text-white bg-gray-900 rounded-lg shadow-sm opacity-0 transition-opacity duration-300 tooltip"
+        >
+          Logout
+          <div class="tooltip-arrow" data-popper-arrow></div>
+        </div>
       </div>
     </div>
     """


### PR DESCRIPTION
This solves a minor bug which I found out while using the application yesterday.
![image](https://github.com/essentiasoftserv/vachan/assets/86550457/ecb9b2f3-c4cf-47bc-a980-14e164e8b063)


The code changes it to : 
![image](https://github.com/essentiasoftserv/vachan/assets/86550457/d4ca95e2-eea8-4919-b2ec-4476fc16c297)
![image](https://github.com/essentiasoftserv/vachan/assets/86550457/5cc09b03-6ae0-4066-aa2f-8a915bd37a82)
